### PR TITLE
if command is `help foo` treat that like calling `foo --help`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function (argv, manifest, rpc, verbose) {
   delete opts._
   if (Object.keys(opts).length)
     args.push(opts)
-
+  console.error('ARGS', args)
   function usage (cmd, opts) {
     // find the closest full help command. foo.bazCommand becomes foo.help (probably).
 
@@ -125,8 +125,12 @@ module.exports = function (argv, manifest, rpc, verbose) {
 
 
   // route to the command
-  if (!cmd)                return usage([]) //print shallow help
-  else if(opts.help) return usage(cmd, Object.assign({deep: true}, opts))
+  if (!cmd)
+    return usage([]) //print shallow help
+  else if(cmd.length == 1 && cmd[0] == 'help' && !opts.json)
+    return usage((args[0] || '').split('.'), Object.assign({deep: true}, opts))
+  else if(opts.help)
+    return usage(cmd, Object.assign({deep: true}, opts))
 
   var cmdType = get(manifest, cmd)
   if(!cmdType)
@@ -189,5 +193,3 @@ module.exports = function (argv, manifest, rpc, verbose) {
     }
   }
 }
-
-

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function (argv, manifest, rpc, verbose) {
   delete opts._
   if (Object.keys(opts).length)
     args.push(opts)
-  console.error('ARGS', args)
+
   function usage (cmd, opts) {
     // find the closest full help command. foo.bazCommand becomes foo.help (probably).
 


### PR DESCRIPTION
when you do help command, it returns rendered help text instead of raw help data. this is what you'd expect, so I think this can be considered a patch not a breaking change. if you use `help --json` then it will call the raw method and output the data. (maybe there is some case where you need to access this from say a bash script?)

cc @christianbundy 